### PR TITLE
feat: JWT 테스트 보강 및 Postman 가이드 추가

### DIFF
--- a/SPRING_SECURITY_TEST.md
+++ b/SPRING_SECURITY_TEST.md
@@ -22,7 +22,7 @@ mvn spring-boot:run
 
 `POST /register` 엔드포인트에 `username`과 `password`를 전송하여 새 사용자를 등록할 수 있습니다. 이 엔드포인트는 인증이 필요 없습니다.
 
-**명령어:**
+**명령어 (모든 환경):**
 ```bash
 curl -X POST -d "username=newuser&password=password" http://localhost:8080/register
 ```
@@ -31,19 +31,51 @@ curl -X POST -d "username=newuser&password=password" http://localhost:8080/regis
 
 등록된 사용자 (또는 기본 `admin` 계정)로 로그인하여 JWT 토큰을 발급받습니다. 이 토큰은 이후 보호된 리소스에 접근할 때 사용됩니다.
 
-**명령어:**
+**명령어 (Linux/macOS 환경):**
 ```bash
-curl -X POST -H "Content-Type: application/json" -d '{"username":"admin", "password":"password"}' http://localhost:8080/api/login
+TOKEN=$(curl -s -X POST -H "Content-Type: application/json" -d '{"username":"admin", "password":"password"}' http://localhost:8080/api/login | grep -o '"jwt":"[^"]*"' | cut -d'"' -f4)
+echo "발급된 토큰: $TOKEN"
+```
+
+**명령어 (Windows Command Prompt (cmd.exe) 환경):**
+```cmd
+@echo off
+for /f "tokens=2 delims=:" %%a in ('curl -s -X POST -H "Content-Type: application/json" -d "{\"username\":\"admin\", \"password\":\"password\"}" http://localhost:8080/api/login ^| findstr /c:"jwt"') do (
+    set "TOKEN=%%a"
+)
+set "TOKEN=%TOKEN:~2,-2%"
+echo 발급된 토큰: %TOKEN%
+```
+
+**명령어 (Windows PowerShell 환경):**
+```powershell
+$response = Invoke-RestMethod -Uri "http://localhost:8080/api/login" -Method Post -Headers @{"Content-Type"="application/json"} -Body '{"username":"admin", "password":"password"}'
+$TOKEN = $response.jwt
+Write-Host "발급된 토큰: $TOKEN"
 ```
 (응답으로 받은 `"jwt"` 값을 복사해두세요. 예: `"eyJhbGciOiJIUzI1NiJ9..."`)
+
+---
 
 ### 3. 발급받은 토큰으로 보호된 리소스 접근
 
 위에서 발급받은 JWT 토큰을 `Authorization: Bearer <토큰값>` 헤더에 포함하여 보호된 엔드포인트에 접근합니다.
 
-**명령어 예시:**
+**명령어 (Linux/macOS 환경):**
 ```bash
-TOKEN="여기에_위에서_받은_JWT_값을_붙여넣으세요" # 예: TOKEN="eyJhbGciOiJIUzI1NiJ9..."
+# 먼저 위 2.2에서 TOKEN 변수를 설정해야 합니다.
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/user/dashboard
+```
+
+**명령어 (Windows Command Prompt (cmd.exe) 환경):**
+```cmd
+:: 먼저 위 2.2에서 TOKEN 변수를 설정해야 합니다.
+curl -H "Authorization: Bearer %TOKEN%" http://localhost:8080/user/dashboard
+```
+
+**명령어 (Windows PowerShell 환경):**
+```powershell
+# 먼저 위 2.2에서 $TOKEN 변수를 설정해야 합니다.
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/user/dashboard
 ```
 
@@ -68,7 +100,7 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/user/dashboard
 
 누구나 접근 가능한 페이지입니다.
 
-**명령어:**
+**명령어 (모든 환경):**
 ```bash
 curl http://localhost:8080/
 ```
@@ -77,9 +109,21 @@ curl http://localhost:8080/
 
 `admin` 계정은 `USER`와 `ADMIN` 권한을 모두 가지고 있습니다. 로그인하여 발급받은 JWT 토큰을 사용합니다.
 
-**명령어:**
+**명령어 (Linux/macOS 환경):**
 ```bash
-TOKEN="여기에_위에서_받은_JWT_값을_붙여넣으세요" # admin 계정으로 발급받은 토큰
+# 먼저 위 2.2에서 TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/user/dashboard
+```
+
+**명령어 (Windows Command Prompt (cmd.exe) 환경):**
+```cmd
+:: 먼저 위 2.2에서 TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
+curl -H "Authorization: Bearer %TOKEN%" http://localhost:8080/user/dashboard
+```
+
+**명령어 (Windows PowerShell 환경):**
+```powershell
+# 먼저 위 2.2에서 $TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/user/dashboard
 ```
 
@@ -87,9 +131,21 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/user/dashboard
 
 `admin` 계정으로 로그인하여 발급받은 JWT 토큰을 사용합니다.
 
-**명령어:**
+**명령어 (Linux/macOS 환경):**
 ```bash
-TOKEN="여기에_위에서_받은_JWT_값을_붙여넣으세요" # admin 계정으로 발급받은 토큰
+# 먼저 위 2.2에서 TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/admin/panel
+```
+
+**명령어 (Windows Command Prompt (cmd.exe) 환경):**
+```cmd
+:: 먼저 위 2.2에서 TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
+curl -H "Authorization: Bearer %TOKEN%" http://localhost:8080/admin/panel
+```
+
+**명령어 (Windows PowerShell 환경):**
+```powershell
+# 먼저 위 2.2에서 $TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/admin/panel
 ```
 
@@ -97,11 +153,26 @@ curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/admin/panel
 
 `newuser` 계정은 `ADMIN` 권한이 없으므로 접근이 거부됩니다 (`403 Forbidden`). `-v` 옵션을 통해 상세한 HTTP 응답을 확인할 수 있습니다.
 
-**명령어:**
+**명령어 (Linux/macOS 환경):**
 ```bash
-# 먼저 newuser로 로그인하여 토큰을 발급받아야 합니다.
-# curl -X POST -H "Content-Type: application/json" -d '{"username":"newuser", "password":"password"}' http://localhost:8080/api/login
-TOKEN="여기에_newuser로_발급받은_JWT_값을_붙여넣으세요"
+# 먼저 newuser로 로그인하여 토큰을 발급받아야 합니다 (위 2.2 참조, username="newuser" 사용).
+# TOKEN=$(curl -s -X POST -H "Content-Type: application/json" -d '{"username":"newuser", "password":"password"}' http://localhost:8080/api/login | grep -o '"jwt":"[^"]*"' | cut -d'"' -f4)
+curl -v -H "Authorization: Bearer $TOKEN" http://localhost:8080/admin/panel
+```
+
+**명령어 (Windows Command Prompt (cmd.exe) 환경):**
+```cmd
+:: 먼저 newuser로 로그인하여 토큰을 발급받아야 합니다 (위 2.2 참조, username="newuser" 사용).
+:: for /f "tokens=2 delims=:" %%a in ('curl -s -X POST -H "Content-Type: application/json" -d "{\"username\":\"newuser\", \"password\":\"password\"}" http://localhost:8080/api/login ^| findstr /c:"jwt"') do (set "TOKEN=%%a")
+:: set "TOKEN=%TOKEN:~2,-2%"
+curl -v -H "Authorization: Bearer %TOKEN%" http://localhost:8080/admin/panel
+```
+
+**명령어 (Windows PowerShell 환경):**
+```powershell
+# 먼저 newuser로 로그인하여 토큰을 발급받아야 합니다 (위 2.2 참조, username="newuser" 사용).
+# $response = Invoke-RestMethod -Uri "http://localhost:8080/api/login" -Method Post -Headers @{"Content-Type"="application/json"} -Body '{"username":"newuser", "password":"password"}'
+# $TOKEN = $response.jwt
 curl -v -H "Authorization: Bearer $TOKEN" http://localhost:8080/admin/panel
 ```
 
@@ -109,10 +180,58 @@ curl -v -H "Authorization: Bearer $TOKEN" http://localhost:8080/admin/panel
 
 `@PreAuthorize("hasRole('ADMIN')")`으로 보호된 메서드에 `admin` 계정으로 로그인하여 발급받은 JWT 토큰을 사용합니다.
 
-**명령어:**
+**명령어 (Linux/macOS 환경):**
 ```bash
-TOKEN="여기에_admin으로_발급받은_JWT_값을_붙여넣으세요"
+# 먼저 위 2.2에서 TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
+curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/secure/method
+```
+
+**명령어 (Windows Command Prompt (cmd.exe) 환경):**
+```cmd
+:: 먼저 위 2.2에서 TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
+curl -H "Authorization: Bearer %TOKEN%" http://localhost:8080/secure/method
+```
+
+**명령어 (Windows PowerShell 환경):**
+```powershell
+# 먼저 위 2.2에서 $TOKEN 변수를 설정해야 합니다 (admin 계정 토큰).
 curl -H "Authorization: Bearer $TOKEN" http://localhost:8080/secure/method
 ```
 
 이제 위 명령어들을 통해 직접 JWT 기반 Spring Security의 경로별, 메서드별 권한 설정을 테스트해보실 수 있습니다.
+
+---
+
+## 4. Postman을 이용한 테스트 방법
+
+[Postman](https://www.postman.com/)과 같은 GUI API 클라이언트를 사용하면 더 편리하게 테스트할 수 있습니다.
+
+### 1. JWT 토큰 발급 (로그인)
+
+1.  Postman에서 새 요청(Request)을 생성합니다.
+2.  HTTP 메서드를 `POST`로 설정하고, URL에 `http://localhost:8080/api/login`을 입력합니다.
+3.  **Headers** 탭으로 이동하여, `Key`에 `Content-Type`, `Value`에 `application/json`을 입력합니다.
+4.  **Body** 탭으로 이동하여, `raw`를 선택하고 타입을 `JSON`으로 변경합니다.
+5.  아래와 같이 로그인 정보를 입력합니다.
+    ```json
+    {
+        "username": "admin",
+        "password": "password"
+    }
+    ```
+6.  **Send** 버튼을 누르면, 아래와 같은 응답을 받게 됩니다.
+    ```json
+    {
+        "jwt": "eyJhbGciOiJIUzI1NiJ9.eyJyb2xlcyI6WyJST0xFX0FETUlOIiwiUk9MRV9VU0VSIl0sInN1YiI6ImFkbWluIiwiaWF0IjoxNzA3MjMyNDc5LCJleHAiOjE3MDczMTg4Nzl9.abcdefg..."
+    }
+    ```
+7.  응답으로 받은 `jwt` 값(큰따옴표 안의 긴 문자열)을 복사합니다.
+
+### 2. 보호된 리소스 접근
+
+1.  Postman에서 다시 새 요청을 생성합니다.
+2.  HTTP 메서드를 `GET`으로 설정하고, URL에 `http://localhost:8080/admin/panel`과 같은 보호된 리소스 주소를 입력합니다.
+3.  **Authorization** 탭으로 이동합니다.
+4.  `Type`을 `Bearer Token`으로 선택합니다.
+5.  오른쪽 `Token` 입력란에 위에서 복사한 **JWT 값**을 붙여넣습니다.
+6.  **Send** 버튼을 누르면, 성공적으로 리소스의 내용(예: "Admin Panel")을 응답으로 받게 됩니다.

--- a/src/main/java/com/example/ch6/spring/security/util/JwtUtil.java
+++ b/src/main/java/com/example/ch6/spring/security/util/JwtUtil.java
@@ -43,16 +43,26 @@ public class JwtUtil {
 
     public String generateToken(UserDetails userDetails) {
         Map<String, Object> claims = new HashMap<>();
-        // You can add more claims here if needed
-        return createToken(claims, userDetails.getUsername());
+        claims.put("roles", userDetails.getAuthorities().stream()
+                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                .collect(java.util.stream.Collectors.toList()));
+        return createToken(claims, userDetails.getUsername(), expiration);
     }
 
-    private String createToken(Map<String, Object> claims, String subject) {
+    public String generateTokenWithExpiration(UserDetails userDetails, long customExpiration) {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("roles", userDetails.getAuthorities().stream()
+                .map(grantedAuthority -> grantedAuthority.getAuthority())
+                .collect(java.util.stream.Collectors.toList()));
+        return createToken(claims, userDetails.getUsername(), customExpiration);
+    }
+
+    private String createToken(Map<String, Object> claims, String subject, long expirationTime) {
         return Jwts.builder()
                 .setClaims(claims)
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+                .setExpiration(new Date(System.currentTimeMillis() + expirationTime))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/test/java/com/example/ch6/spring/security/JwtAuthenticationTest.java
+++ b/src/test/java/com/example/ch6/spring/security/JwtAuthenticationTest.java
@@ -2,22 +2,38 @@ package com.example.ch6.spring.security;
 
 import com.example.ch6.spring.security.controller.AuthenticationRequest;
 import com.example.ch6.spring.security.controller.AuthenticationResponse;
+import com.example.ch6.spring.security.service.JpaUserDetailsService;
+import com.example.ch6.spring.security.util.JwtUtil;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.*;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class JwtAuthenticationTest {
 
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Autowired
+    private JpaUserDetailsService userDetailsService;
+
     @Test
+    @Order(1)
     @DisplayName("1. 로그인 성공 시 JWT 토큰을 발급받는다")
     public void testLoginAndGetJwt() {
         // given
@@ -34,9 +50,10 @@ public class JwtAuthenticationTest {
     }
 
     @Test
-    @DisplayName("2. 유효한 JWT 토큰으로 보호된 리소스에 접근한다")
+    @Order(2)
+    @DisplayName("2. 유효한 JWT 토큰으로 보호된 리소스에 접근한다 (Admin)")
     public void testAccessProtectedResourceWithValidJwt() {
-        // given: First, get a valid token
+        // given: First, get a valid token for admin
         AuthenticationRequest loginRequest = new AuthenticationRequest("admin", "password");
         ResponseEntity<AuthenticationResponse> loginResponse = restTemplate.postForEntity("/api/login", loginRequest, AuthenticationResponse.class);
         String token = loginResponse.getBody().getJwt();
@@ -53,6 +70,7 @@ public class JwtAuthenticationTest {
     }
 
     @Test
+    @Order(3)
     @DisplayName("3. JWT 토큰 없이 보호된 리소스에 접근 시 403 Forbidden을 받는다")
     public void testAccessProtectedResourceWithoutJwt() {
         // when
@@ -63,6 +81,7 @@ public class JwtAuthenticationTest {
     }
 
     @Test
+    @Order(4)
     @DisplayName("4. 유효하지 않은 JWT 토큰으로 보호된 리소스에 접근 시 403 Forbidden을 받는다")
     public void testAccessProtectedResourceWithInvalidJwt() {
         // given
@@ -72,6 +91,84 @@ public class JwtAuthenticationTest {
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
         // when
+        ResponseEntity<String> response = restTemplate.exchange("/admin/panel", HttpMethod.GET, entity, String.class);
+
+        // then
+        assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode());
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("5. 생성된 JWT 토큰을 파싱하여 내용(Claims)을 검증한다")
+    public void testDecodeJwtAndVerifyClaims() {
+        // given: Load admin user and generate a token
+        UserDetails userDetails = userDetailsService.loadUserByUsername("admin");
+        String token = jwtUtil.generateToken(userDetails);
+        System.out.println("Generated Token: " + token);
+
+        // when: Extract claims from the token
+        String username = jwtUtil.extractUsername(token);
+        List<String> roles = jwtUtil.extractClaim(token, claims -> claims.get("roles", List.class));
+        java.util.Date expiration = jwtUtil.extractExpiration(token);
+
+        // then: Print and verify the claims
+        System.out.println("\n--- Decoded JWT Payload ---");
+        System.out.println("sub (Subject/Username): " + username);
+        System.out.println("roles (Authorities): " + roles);
+        System.out.println("exp (Expiration Time): " + expiration);
+        System.out.println("---------------------------\n");
+
+        assertEquals("admin", username);
+        assertTrue(roles.contains("ROLE_ADMIN"));
+        assertTrue(roles.contains("ROLE_USER"));
+        assertTrue(expiration.after(new java.util.Date()));
+    }
+
+    @Test
+    @Order(6)
+    @DisplayName("6. USER 역할 사용자의 권한을 테스트한다")
+    public void testUserRoleAccess() {
+        // given: Register a new user
+        HttpHeaders registerHeaders = new HttpHeaders();
+        registerHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        org.springframework.util.MultiValueMap<String, String> map = new org.springframework.util.LinkedMultiValueMap<>();
+        map.add("username", "newuser");
+        map.add("password", "password");
+        HttpEntity<org.springframework.util.MultiValueMap<String, String>> registerRequest = new HttpEntity<>(map, registerHeaders);
+        restTemplate.postForEntity("/register", registerRequest, String.class);
+
+        // and: log in as the new user
+        AuthenticationRequest loginRequest = new AuthenticationRequest("newuser", "password");
+        ResponseEntity<AuthenticationResponse> loginResponse = restTemplate.postForEntity("/api/login", loginRequest, AuthenticationResponse.class);
+        String token = loginResponse.getBody().getJwt();
+
+        // when: Access user and admin dashboards
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(token);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<String> userResponse = restTemplate.exchange("/user/dashboard", HttpMethod.GET, entity, String.class);
+        ResponseEntity<String> adminResponse = restTemplate.exchange("/admin/panel", HttpMethod.GET, entity, String.class);
+
+        // then
+        assertEquals(HttpStatus.OK, userResponse.getStatusCode());
+        assertTrue(userResponse.getBody().contains("User Dashboard"));
+        assertEquals(HttpStatus.FORBIDDEN, adminResponse.getStatusCode());
+    }
+
+    @Test
+    @Order(7)
+    @DisplayName("7. 만료된 JWT 토큰으로 접근 시 403 Forbidden을 받는다")
+    public void testExpiredJwtToken() throws InterruptedException {
+        // given: Generate a token that expires in 1 millisecond
+        UserDetails userDetails = userDetailsService.loadUserByUsername("admin");
+        String expiredToken = jwtUtil.generateTokenWithExpiration(userDetails, 1);
+
+        // when: Wait for the token to expire and then use it
+        Thread.sleep(5); // Wait 5ms to ensure expiration
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(expiredToken);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<String> response = restTemplate.exchange("/admin/panel", HttpMethod.GET, entity, String.class);
 
         // then


### PR DESCRIPTION
JWT 인증 테스트 케이스를 보강하고, Postman을 이용한 테스트 방법을 가이드에 추가합니다.

- JwtUtil: 테스트를 위한 커스텀 만료 시간 토큰 생성 메서드 추가

- JwtAuthenticationTest: USER 역할 접근, 만료된 토큰 테스트 등 추가 테스트 케이스 구현 및 테스트 순서 재정렬

- SPRING_SECURITY_TEST.md: Postman 테스트 방법 및 플랫폼별 curl 명령어 상세화